### PR TITLE
Update build system and Travis integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,26 +1,10 @@
 *.swp
 
 /doc/
-/cnf/
-/gen/
 
-.deps/
-.dirstamp
-.libs/
-
-/aclocal.m4
-/autom4te.cache/
 /bin/
-/config.log
-/config.status
-/lib/
-/libtool
+/gen/
 /Makefile
-/src/pkgconfig.h
-/src/stamp-h1
-
-*.la
-src/*.lo
 
 /tmp/
 /gh-pages/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ dist: xenial
 language: c
 env:
   global:
-    - GAPROOT=gaproot
-    - COVDIR=coverage
     - GAP_PKGS_TO_CLONE="ferret PARIInterface"
     - GAP_PKGS_TO_BUILD="io profiling ferret digraphs PARIInterface"
 
@@ -11,26 +9,23 @@ addons:
   apt_packages:
     - libgmp-dev
     - libreadline-dev
+    - zlib1g-dev
     - libpari-dev # for PARIInterface
 
 matrix:
   include:
-    - env: CFLAGS="-O2" CC=clang CXX=clang++
-      compiler: clang
-    - env: CFLAGS="-O2"
-      compiler: gcc
-    - env: CFLAGS=""  # test build w/o optimization
+    - env: GAPBRANCH=master
+    - env: GAPBRANCH=stable-4.11
 
 branches:
   only:
     - master
 
 before_script:
-  - export GAPROOT="$HOME/gap"
   - git clone https://github.com/gap-system/pkg-ci-scripts.git scripts
   - scripts/build_gap.sh
 script:
   - scripts/build_pkg.sh && scripts/run_tests.sh
 after_script:
-  - bash scripts/gather-coverage.sh
+  - scripts/gather-coverage.sh
   - bash <(curl -s https://codecov.io/bash)

--- a/Makefile.gappkg
+++ b/Makefile.gappkg
@@ -1,0 +1,146 @@
+########################################################################
+#
+# The build rules in this file are intended for use by GAP packages that
+# want to build a simple GAP kernel extensions. They are based on the
+# GAP build system, and require GNU make. To use this in your GAP
+# package, `include` this from your primary Makefile. You must also set
+# several variables beforehand:
+#
+# - GAPPATH must be set to the location of the GAP installation against
+#   which to build your package.
+# - KEXT_NAME should be the name of your kernel extension (without
+#   file extensions like .so or .dll)
+# - KEXT_SOURCES must contain a list of .c or .cc files to be linked
+#   into your kernel extension
+# - optionally, you can set KEXT_CFLAGS, KEXT_CXXFLAGS, KEXT_LDFLAGS
+#
+#
+# Only GAP >= 4.11 ships with this file. In order to keep your package
+# compatible with older GAP versions, we recommend to bundle a copy of
+# it with your package, but only as a fallback. So, your configure
+# scripts should check if GAP ships with this file, and use it then, and
+# only fall back to your own copy as a last resort. This way, you will
+# benefit from any fixes and improvements made by the GAP team.
+#
+# The contents of this file are released into the public domain; hence
+# you may edit this file as you wish, bundle and distribute it with your
+# package, etc.
+#
+# If you bundle this file with your package, please try not to edit it,
+# so that we can keep it identical across all GAP packages. If you still
+# find that you must edit it, please consider submitting your changes
+# back to the GAP team, so that a future version of this file can be
+# adjusted to cover your usecase without modifications.
+#
+########################################################################
+
+# read GAP's build settings
+include $(GAPPATH)/sysinfo.gap
+
+# various derived settings
+KEXT_BINARCHDIR = bin/$(GAParch)
+KEXT_SO = $(KEXT_BINARCHDIR)/$(KEXT_NAME).so
+
+GAP = $(GAPPATH)/gap
+GAC = $(GAPPATH)/gac
+
+# override KEXT_RECONF if your package needs a different invocation
+# for reconfiguring (e.g. `./config.status --recheck` for autoconf)
+KEXT_RECONF ?= ./configure "$(GAPPATH)"
+
+# default target
+all: $(KEXT_SO)
+.PHONY: all
+
+########################################################################
+# Object files
+# For each file FOO.c in SOURCES, add gen/FOO.lo to KEXT_OBJS; similar
+# for .cc files
+########################################################################
+KEXT_OBJS = $(patsubst %.cc,gen/%.lo,$(patsubst %.c,gen/%.lo,$(KEXT_SOURCES)))
+
+########################################################################
+# Quiet rules.
+#
+# Replace regular output with quiet messages, unless V is set,
+# e.g. "make V=1"
+########################################################################
+ifneq ($(findstring $(MAKEFLAGS),s),s)
+ifndef V
+QUIET_GAC     = @echo "   GAC     $< => $@";
+endif
+endif
+
+########################################################################
+# Rules for automatic header dependency tracking.
+# This is based on the GAP build system.
+########################################################################
+
+# List of all (potential) dependency directories, derived from KEXT_OBJS
+# and KEXT_SOURCES (the latter for generated sources, which may also
+# involve dependency tracking)
+KEXT_DEPDIRS = $(sort $(dir $(KEXT_SOURCES) $(KEXT_OBJS)))
+KEXT_DEPFILES = $(wildcard $(addsuffix /*.d,$(KEXT_DEPDIRS)))
+
+# Include the dependency tracking files.
+-include $(KEXT_DEPFILES)
+
+# Mark *.d files as PHONY. This stops make from trying to recreate them
+# (which it can't), and in particular from looking for potential source
+# files. This can save quite a bit of disk access time.
+.PHONY: $(KEXT_DEPFILES)
+
+# The following flags instruct the compiler to enable advanced
+# dependency tracking. Supported by GCC 3 and newer; clang; Intel C
+# compiler; and more.
+KEXT_DEPFLAGS = -MQ "$@" -MMD -MP -MF $(@D)/$(*F).d
+
+# build rule for C code
+# The dependency on Makefile ensures that re-running configure recompiles everything
+gen/%.lo: %.c Makefile
+	$(QUIET_GAC)$(GAC) -d -p "$(KEXT_DEPFLAGS)" -p "$(KEXT_CFLAGS)" -c $< -o $@
+
+# build rule for C++ code
+# The dependency on Makefile ensures that re-running configure recompiles everything
+gen/%.lo: %.cc Makefile
+	$(QUIET_GAC)$(GAC) -d -p "$(KEXT_DEPFLAGS)" -p "$(KEXT_CXXFLAGS)" -c $< -o $@
+
+# build rule for linking all object files together into a kernel extension
+$(KEXT_SO): $(KEXT_OBJS)
+	@mkdir -p $(KEXT_BINARCHDIR)
+	$(QUIET_GAC)$(GAC) -d -p "$(KEXT_DEPFLAGS)" -P "$(KEXT_LDFLAGS)" $(KEXT_OBJS) -o $@
+
+# hook into `make clean`
+clean: clean-kext
+clean-kext:
+	rm -rf $(KEXT_BINARCHDIR) gen
+
+# hook into `make distclean`
+distclean: clean-kext
+distclean-kext:
+	rm -rf bin gen Makefile
+	(cd doc && ./clean)
+
+# hook into `make doc`
+doc: doc-kext
+doc-kext:
+	$(GAP) makedoc.g
+
+# hook into `make check`
+check: check-kext
+check-kext:
+	$(GAP) tst/testall.g
+
+# re-run configure if configure, Makefile.in or GAP itself changed
+Makefile: configure Makefile.in $(GAPPATH)/sysinfo.gap
+	$(KEXT_RECONF)
+
+.PHONY: check clean distclean doc
+.PHONY: check-kext clean-kext distclean-kext doc-kext
+
+########################################################################
+# Makefile debugging trick:
+# call print-VARIABLE to see the runtime value of any variable
+########################################################################
+print-%:
+	@echo '$*=$($*)'

--- a/Makefile.in
+++ b/Makefile.in
@@ -1,124 +1,17 @@
 #
 # Makefile rules for the GaloisGroups package
 #
-# This requires GNU make (just as the main GAP does).
-#
-# For simple packages one should only need to modify the MODULE_NAME
-# and the SOURCES variable.
-#
-MODULE_NAME = GaloisGroups
+KEXT_NAME = GaloisGroups
+KEXT_SOURCES = src/GaloisGroups.c
 
-SOURCES = src/GaloisGroups.c
+PARIPATH = @PARIPATH@
+KEXT_CFLAGS = @EXTRA_CPPFLAGS@
+KEXT_LDFLAGS = @EXTRA_LDFLAGS@
 
-TOP = $(shell pwd)
-EXTRA_CPPFLAGS = @EXTRA_CPPFLAGS@
-EXTRA_LDFLAGS = @EXTRA_LDFLAGS@
-EXTERN_FILES =
-
-########################################################################
-# Do not edit below unless you know what you're doing
-########################################################################
-
-########################################################################
-# Some variables that come from GAP via our configure script
-########################################################################
+# include shared GAP package build system
 GAPPATH = @GAPPATH@
-GAPARCH = @GAPARCH@
+include Makefile.gappkg
 
-BINARCHDIR = bin/@GAPARCH@
-GAPINSTALLIB = $(BINARCHDIR)/$(MODULE_NAME).so
-
-MKDIR_P = /bin/mkdir -p
-
-GAP = @GAPPATH@/gap
-GAC = @GAPPATH@/gac
-
-all: $(GAPINSTALLIB)
-.PHONY: all
-
-########################################################################
-# Object files
-# For each file FOO.c in SOURCES, add gen/FOO.lo to OBJS; similar
-# for .cc files
-########################################################################
-OBJS = $(patsubst %.cc,gen/%.lo,$(patsubst %.c,gen/%.lo,$(SOURCES)))
-
-########################################################################
-# Quiet rules.
-#
-# Replace regular output with quiet messages, unless V is set,
-# e.g. "make V=1"
-########################################################################
-ifneq ($(findstring $(MAKEFLAGS),s),s)
-ifndef V
-QUIET_GAC     = @echo "   GAC     $< => $@";
-LIBTOOL          += --silent
+ifneq ($(PARIPATH),)
+  KEXT_RECONF += --with-pari "$(PARIPATH)"
 endif
-endif
-
-########################################################################
-# Rules for automatic header dependency tracking.
-# This is based on the GAP build system.
-########################################################################
-
-# List of all (potential) dependency directories, derived from OBJS
-# and SOURCES (the latter for generated sources, which may also involve
-# dependency tracking)
-DEPDIRS = $(sort $(dir $(SOURCES) $(OBJS)))
-ALL_DEP_FILES = $(wildcard $(addsuffix /*.d,$(DEPDIRS)))
-
-# Include the dependency tracking files.
--include $(ALL_DEP_FILES)
-
-# Mark *.d files as PHONY. This stops make from trying to
-# recreate them (which it can't), and in particular from looking for potential
-# source files. This can save quite a bit of disk access time.
-.PHONY: $(ALL_DEP_FILES)
-
-# The following flags instruct the compiler to enable advanced
-# dependency tracking. Supported by GCC 3 and newer; clang; Intel C
-# compiler; and more.
-DEPFLAGS = -MQ "$@" -MMD -MP -MF $(@D)/$(*F).d
-
-# build rule for C code
-gen/%.lo: %.c
-	@$(QUIET_GAC)$(GAC) -d -p "$(DEPFLAGS)" -p "$(EXTRA_CPPFLAGS)" -c $< -o $@
-
-# build rule for C++ code
-gen/%.lo: %.cc
-	@$(QUIET_GAC)$(GAC) -d -p "$(DEPFLAGS)" -p "$(EXTRA_CPPFLAGS)" -c $< -o $@
-
-# build rule for linking all object files together into a kernel extension
-# TODO: detect pari lib and header files
-$(GAPINSTALLIB): $(OBJS)
-	@$(MKDIR_P) $(BINARCHDIR)
-	@$(QUIET_GAC)$(GAC) -d -p "$(DEPFLAGS)" $(OBJS) -L "$(EXTRA_LDFLAGS)" -o $@
-
-clean:
-	rm -rf $(BINARCHDIR)
-	rm -rf gen
-
-distclean:
-	rm -rf bin gen Makefile
-	(cd doc && ./clean)
-
-doc: default
-	$(GAP) makedoc.g
-
-check: default
-	$(GAP) tst/testall.g
-
-Makefile: configure Makefile.in
-	./configure "@GAPPATH@"
-
-.PHONY: default clean distclean doc check
-
-$(OBJS): $(EXTERN_FILES)
-$(GAPINSTALLIB): $(EXTERN_FILES)
-
-########################################################################
-# Makefile debugging trick:
-# call print-VARIABLE to see the runtime value of any variable
-########################################################################
-print-%:
-	@echo '$*=$($*)'

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -102,7 +102,7 @@ PackageDoc := rec(
 ),
 
 Dependencies := rec(
-  GAP := ">= 4.8",
+  GAP := ">= 4.11",
   NeededOtherPackages := [ [ "GAPDoc", ">= 1.6" ]
                          , [ "Digraphs", ">= 0.11" ]
                          , [ "ferret", ">= 0.8.0" ]

--- a/configure
+++ b/configure
@@ -22,17 +22,19 @@ function error_msg_and_quit {
     exit 1
 }
 
-GAPPATH=../..;
+GAPPATH=../..
+PARIPATH=
 
 while [[ $# -gt 0 ]]; do
     key="$1"
 
     case $key in
         --with-pari)
+        PARIPATH="$2"
         EXTRA_CPPFLAGS="-I$2/include"
         EXTRA_LDFLAGS="-L$2/lib"
         if test ! -r $2/include/pari/pari.h; then
-            error_msg_and_quit "$2 does not look like a proper pari installtion tree"
+            error_msg_and_quit "$2 does not look like a proper pari installation tree"
         fi
         shift
         shift
@@ -53,12 +55,14 @@ fi
 # "-L/opt/pari/gp-galois/lib"
 #
 
-echo "Using config in $GAPPATH/sysinfo.gap"
+echo "Using settings from $GAPPATH/sysinfo.gap"
 
-. "$GAPPATH/sysinfo.gap"
+# update Makefile.gappkg from GAP installation, if possible
+test -r "$GAPPATH/etc/Makefile.gappkg" && cp "$GAPPATH/etc/Makefile.gappkg" .
+
 sed \
-    -e "s;@GAPARCH@;$GAParch;g" \
     -e "s;@GAPPATH@;$GAPPATH;g" \
+    -e "s;@PARIPATH@;$PARIPATH;g" \
     -e "s;@EXTRA_CPPFLAGS@;$EXTRA_CPPFLAGS;g" \
     -e "s;@EXTRA_LDFLAGS@;$EXTRA_LDFLAGS;g" \
     Makefile.in > Makefile


### PR DESCRIPTION
Travis:
- test against GAP 4.9, 4.10, 4.11 and master
- install zlib headers so that GAP doesn't have to compile zlib

Build system:
- put common GAP kernel extension build rules into Makefile.gappkg